### PR TITLE
Update Twitter.Bootstrap.MVC/BootstrapBundleConfig.cs.pp

### DIFF
--- a/Twitter.Bootstrap.MVC/BootstrapBundleConfig.cs.pp
+++ b/Twitter.Bootstrap.MVC/BootstrapBundleConfig.cs.pp
@@ -1,6 +1,6 @@
 ﻿using System.Web.Optimization;
 
-[assembly: WebActivator.PostApplicationStartMethod(typeof($rootnamespace$.App_Start.BootstrapBundleConfig), "RegisterBundles")]
+[assembly: WebActivatorEx.PostApplicationStartMethod(typeof($rootnamespace$.App_Start.BootstrapBundleConfig), "RegisterBundles")]
 
 namespace $rootnamespace$.App_Start
 {


### PR DESCRIPTION
The "WebActivator" namespace does not exist in the new WebActivatorEx dll. It's called "WebActivatorEx", when installing the nuget package the project can't build
